### PR TITLE
Fix require statement

### DIFF
--- a/lib/fluent/plugin/filter_explode.rb
+++ b/lib/fluent/plugin/filter_explode.rb
@@ -1,5 +1,5 @@
 require 'fluent/filter'
-require 'fluent/plugin_mixin/mutate_event'
+require 'fluent/plugin/mixin/mutate_event'
 
 module Fluent
   class ExplodeFilter < Filter


### PR DESCRIPTION
I saw a stacktrace come through when using this plugin. It appears that the require statement had a typo causing the plugin to fail. After making the change, I reran the ruby file and it exited successfully. I also made this change in my local gem directory and saved it, then re-ran the fluentd dry-run script and it appeared to alleviate the issue in the plugin.